### PR TITLE
adding tests for jobs and accounts API

### DIFF
--- a/_common/shippable/Adapter.js
+++ b/_common/shippable/Adapter.js
@@ -82,6 +82,22 @@ ShippableAdapter.prototype.getAccounts =
     );
   };
 
+ShippableAdapter.prototype.getAccountDependenciesById =
+  function (id, callback) {
+    this.get(
+      util.format('/accounts/%s/dependencies', id),
+      callback
+    );
+  };
+
+ShippableAdapter.prototype.getRunStatusByAccountId =
+  function (id, callback) {
+    this.get(
+      util.format('/accounts/%s/runStatus', id),
+      callback
+    );
+  };
+
 ShippableAdapter.prototype.getAccountIntegrationById =
   function (id, callback) {
     this.get(
@@ -784,6 +800,14 @@ ShippableAdapter.prototype.deleteJobConsolesByJobId =
     var url = util.format('/jobs/%s/consoles?%s',
       jobId, query);
     this.delete(url, callback);
+  };
+
+ShippableAdapter.prototype.deleteJobsById =
+  function (jobId, callback) {
+    this.delete(
+      util.format('/jobs/%s', jobId),
+      callback
+    );
   };
 
 ShippableAdapter.prototype.postOfflineAccount =

--- a/tests/core/api/ACCOUNTS.js
+++ b/tests/core/api/ACCOUNTS.js
@@ -1,0 +1,475 @@
+'use strict';
+
+var testSetup = require('../../../testSetup.js');
+var backoff = require('backoff');
+
+var testSuite = 'API_ACCOUNTS';
+var testSuiteDesc = 'API tests for accounts';
+var test = util.format('%s - %s', testSuite, testSuiteDesc);
+
+describe(test,
+  function () {
+    var ownerApiAdapter = null;
+    var collaboraterApiAdapter = null;
+    var memberApiAdapter = null;
+    var unauthorizedApiAdapter = null;
+    var project = {};
+    var runId = null;
+    var accounts = [];
+    var account = {};
+    var accountDependencies = {};
+    var runStatus ={};
+    var successStatusCode = null;
+
+    this.timeout(0);
+    before(
+      function (done) {
+        async.series(
+          [
+            testSetup.bind(null)
+          ],
+          function (err) {
+            if (err) {
+              logger.error(test, 'Failed to setup tests. err:', err);
+              return done(err);
+            }
+            ownerApiAdapter =
+              global.newApiAdapterByStateAccount('ghOwnerAccount');
+            collaboraterApiAdapter =
+              global.newApiAdapterByStateAccount('ghCollaboratorAccount');
+            memberApiAdapter =
+              global.newApiAdapterByStateAccount('ghMemberAccount');
+            unauthorizedApiAdapter =
+              global.newApiAdapterByStateAccount('ghUnauthorizedAccount');
+
+            successStatusCode = _.findWhere(global.systemCodes,
+              {group: 'statusCodes', name: 'SUCCESS'}).code;
+
+            ownerApiAdapter.getProjects('',
+              function (err, prjs) {
+                if (err || _.isEmpty(prjs))
+                  return done(new Error('Project list is empty', err));
+
+                project = _.first(
+                  _.where(prjs, {isOrg: true, isPrivateRepository: true}
+                  )
+                );
+
+                project.test_resource_type = 'project';
+                project.test_resource_name = 'ghOrgPrivate';
+                assert.isNotEmpty(project, 'User cannot find the project');
+
+                return done();
+              }
+            );
+          }
+        );
+      }
+    );
+
+    it('1. Owner enables the project',
+      function (done) {
+        var json = {
+          type: 'ci'
+        };
+        ownerApiAdapter.enableProjectById(project.id, json,
+          function (err, response) {
+            if (err)
+              return done(
+                new Error(
+                  util.format('User cannot enable the project with id:%s %s',
+                    project.id, util.inspect(response))
+                )
+              );
+
+            global.saveTestResource(project.test_resource_name, project,
+              function () {
+                return done();
+              }
+            );
+          }
+        );
+      }
+    );
+
+    it('2. Owner triggers manual build for the project and was successful',
+      function (done) {
+        var triggerBuild = new Promise(
+          function (resolve, reject) {
+            var json = {branchName: 'master'};
+            ownerApiAdapter.triggerNewBuildByProjectId(project.id, json,
+              function (err, response) {
+                if (err)
+                  return reject(
+                    new Error(
+                      util.format('user cannot trigger manual build for ' +
+                        'project id: %s, err: %s, %s', project.id, err,
+                        util.inspect(response)
+                      )
+                    )
+                  );
+                return resolve(response);
+              }
+            );
+          }
+        );
+
+        triggerBuild.then(
+          function (response) {
+            runId = response.runId;
+            global.getRunByIdStatusWithBackOff(ownerApiAdapter, runId,
+              successStatusCode, done);
+          },
+          function (err) {
+            return done(err);
+          }
+        );
+      }
+    );
+
+    it('3. Owner can get their account',
+      function (done) {
+        ownerApiAdapter.getAccounts('',
+          function (err, acts) {
+            if (err || _.isEmpty(acts))
+              return done(
+                new Error(
+                  util.format('User cannot get account',
+                    query, err)
+                )
+              );
+            accounts = acts;
+            assert.isNotEmpty(accounts, 'User cannot find the account');
+            return done();
+          }
+        );
+      }
+    );
+
+    it('4. Member can get their account',
+      function (done) {
+        memberApiAdapter.getAccounts('',
+          function (err, acts) {
+            if (err || _.isEmpty(acts))
+              return done(
+                new Error(
+                  util.format('User cannot get account',
+                    query, err)
+                )
+              );
+            accounts = acts;
+            assert.isNotEmpty(accounts, 'User cannot find the account');
+            return done();
+          }
+        );
+      }
+    );
+
+    it('5. Collaborater can get their account',
+      function (done) {
+        collaboraterApiAdapter.getAccounts('',
+          function (err, acts) {
+            if (err || _.isEmpty(acts))
+              return done(
+                new Error(
+                  util.format('User cannot get account',
+                    query, err)
+                )
+              );
+            accounts = acts;
+            assert.isNotEmpty(accounts, 'User cannot find the account');
+            return done();
+          }
+        );
+      }
+    );
+
+    it('6. Public user cannot get their accounts',
+      function (done) {
+        global.pubAdapter.getAccounts('',
+          function (err, acts) {
+            assert.strictEqual(err, 401,
+              util.format('User should not be able to get the account' +
+                'err : %s %s', err, acts)
+            );
+            return done();
+          }
+        );
+      }
+    );
+
+    it('7. Unauthorized user cannot get their accounts',
+      function (done) {
+        unauthorizedApiAdapter.getAccounts('',
+          function (err, acts) {
+            if (err || _.isEmpty(acts))
+              return done(
+                new Error(
+                  util.format('User cannot get account',
+                    query, err)
+                )
+              );
+            accounts = acts;
+            assert.isNotEmpty(accounts, 'User cannot find the account');
+            return done();
+          }
+        );
+      }
+    );
+
+
+    it('8. Owner can get account By Id',
+      function (done) {
+        ownerApiAdapter.getAccountById(project.ownerAccountId,
+          function (err, act) {
+            if (err || _.isEmpty(act))
+              return done(
+                new Error(
+                  util.format('User cannot get account from Id',
+                    query, err)
+                )
+              );
+            account = act;
+            assert.isNotEmpty(account, 'User cannot find the account from Id');
+            return done();
+          }
+        );
+      }
+    );
+
+    it('9. Member cannot get account By Id',
+      function (done) {
+        memberApiAdapter.getAccountById(project.ownerAccountId,
+          function (err, act) {
+            assert.strictEqual(err, 401,
+              util.format('User should not be able to get the account from Id' +
+                'err : %s %s', err, act)
+            );
+            return done();
+          }
+        );
+      }
+    );
+
+    it('10. Collaborater cannot get account By Id',
+      function (done) {
+        collaboraterApiAdapter.getAccountById(project.ownerAccountId,
+          function (err, act) {
+            assert.strictEqual(err, 401,
+              util.format('User should not be able to get the account from Id' +
+                'err : %s %s', err, act)
+            );
+            return done();
+          }
+        );
+      }
+    );
+
+    it('11. Public user cannot get account By Id',
+      function (done) {
+        global.pubAdapter.getAccountById(project.ownerAccountId,
+          function (err, act) {
+            assert.strictEqual(err, 401,
+              util.format('User should not be able to get the account from Id' +
+                'err : %s %s', err, act)
+            );
+            return done();
+          }
+        );
+      }
+    );
+
+    it('12. Unauthorized user cannot get account By Id',
+      function (done) {
+        unauthorizedApiAdapter.getAccountById(project.ownerAccountId,
+          function (err, act) {
+            assert.strictEqual(err, 401,
+              util.format('User should not be able to get the account from Id' +
+                'err : %s %s', err, act)
+            );
+            return done();
+          }
+        );
+      }
+    );
+
+    it('13. Owner can get account dependencies By Id',
+      function (done) {
+        ownerApiAdapter.getAccountDependenciesById(project.ownerAccountId,
+          function (err, actDep) {
+            if (err || _.isEmpty(actDep))
+              return done(
+                new Error(
+                  util.format('User cannot get account dependencies from Id',
+                    query, err)
+                )
+              );
+            accountDependencies = actDep;
+            assert.isNotEmpty(accountDependencies, 'User cannot find the account dependencies from Id');
+            return done();
+          }
+        );
+      }
+    );
+
+    it('14. Member can get account dependencies By Id',
+      function (done) {
+        memberApiAdapter.getAccountDependenciesById(project.ownerAccountId,
+          function (err, act) {
+            assert.strictEqual(err, 401,
+              util.format('User should not be able to get the account dependencies from Id' +
+                'err : %s %s', err, act)
+            );
+            return done();
+          }
+        );
+      }
+    );
+
+    it('15. Collaborater can get account dependencies By Id',
+      function (done) {
+        collaboraterApiAdapter.getAccountDependenciesById(project.ownerAccountId,
+          function (err, act) {
+            assert.strictEqual(err, 401,
+              util.format('User should not be able to get the account dependencies from Id' +
+                'err : %s %s', err, act)
+            );
+            return done();
+          }
+        );
+      }
+    )
+
+    it('16. Public user can get account dependencies By Id',
+      function (done) {
+        global.pubAdapter.getAccountDependenciesById(project.ownerAccountId,
+          function (err, act) {
+            assert.strictEqual(err, 401,
+              util.format('User should not be able to get the account dependencies from Id' +
+                'err : %s %s', err, act)
+            );
+            return done();
+          }
+        );
+      }
+    );
+
+    it('17. Unauthorized user can get account dependencies By Id',
+      function (done) {
+        unauthorizedApiAdapter.getAccountDependenciesById(project.ownerAccountId,
+          function (err, act) {
+            assert.strictEqual(err, 401,
+              util.format('User should not be able to get the account dependencies from Id' +
+                'err : %s %s', err, act)
+            );
+            return done();
+          }
+        );
+      }
+    );
+
+    it('18. Owner can get Run Status by account ID',
+      function (done) {
+        ownerApiAdapter.getRunStatusByAccountId(project.ownerAccountId,
+          function (err, runStas) {
+            if (err || _.isEmpty(runStas))
+              return done(
+                new Error(
+                  util.format('User cannot get run status from account Id',
+                    ownerAccountId, err)
+                )
+              );
+
+            runStatus = runStas;
+            assert.isNotEmpty(runStatus, 'User cannot find the run status by account Id');
+            return done();
+          }
+        );
+      }
+    );
+
+    it('19. Member can get Run Status by account ID',
+      function (done) {
+        memberApiAdapter.getRunStatusByAccountId(project.ownerAccountId,
+          function (err, runStas) {
+            assert.strictEqual(err, 401,
+              util.format('User should not be able to get the runstatus by account Id' +
+                'err : %s %s', err, runStas)
+            );
+            return done();
+          }
+        );
+      }
+    );
+
+    it('20. Collaborator can get Run Status by account ID',
+      function (done) {
+        collaboraterApiAdapter.getRunStatusByAccountId(project.ownerAccountId,
+          function (err, runStas) {
+            assert.strictEqual(err, 401,
+              util.format('User should not be able to get the runstatus by account Id' +
+                'err : %s %s', err, runStas)
+            );
+            return done();
+          }
+        );
+      }
+    );
+
+    it('21. public user cannot get Run Status by subscription ID',
+      function (done) {
+        global.pubAdapter.getRunStatusByAccountId(project.ownerAccountId,
+          function (err, runStas) {
+            assert.strictEqual(err, 401,
+              util.format('User should not be able to get the runstatus by account Id' +
+                'err : %s %s', err, runStas)
+            );
+            return done();
+          }
+        );
+      }
+    );
+
+    it('22. unauthorized user cannot get Run Status by subscription ID',
+      function (done) {
+        unauthorizedApiAdapter.getRunStatusByAccountId(project.ownerAccountId,
+          function (err, runStas) {
+            assert.strictEqual(err, 401,
+              util.format('User should not be able to get the runstatus by account Id' +
+                'err : %s %s', err, runStas)
+            );
+            return done();
+          }
+        );
+      }
+    );
+
+    it('23. Owner deletes the project',
+      function (done) {
+        var json = {projectId: project.id};
+        ownerApiAdapter.deleteProjectById(project.id, json,
+          function (err, response) {
+            if (err)
+              return done(
+                new Error(
+                  util.format('User can delete project id: %s, err: %s, %s',
+                    project.id, err, response)
+                )
+              );
+            global.removeTestResource(project.test_resource_name,
+              function () {
+                return done();
+              }
+            );
+          }
+        );
+      }
+    );
+
+    after(
+      function (done) {
+        return done();
+      }
+    );
+  }
+);

--- a/tests/core/api/JOBS.js
+++ b/tests/core/api/JOBS.js
@@ -410,7 +410,108 @@ describe(test,
       }
     );
 
-    it('17. Owner deletes the private project',
+    it('17. Owner can delete job by job Id',
+      function (done) {
+        ownerApiAdapter.deleteJobsById(privateProjectJob.id,
+          function (err) {
+            if (err)
+              return done(
+                new Error(
+                  util.format('User cannot delete job by job Id %s err %s',
+                    publicProjectJob.id, err)
+                )
+              );
+            return done();
+          }
+        );
+      }
+    );
+
+    it('18. Member cannot delete job by job Id',
+      function (done) {
+        memberApiAdapter.deleteJobsById(privateProjectJob.id,
+          function (err, response) {
+            assert.strictEqual(err, 404,
+              util.format('User should not be able to delete job by job Id: %s ' +
+                'err : %s, %s', privateProjectJob.id, err, response)
+            );
+            return done();
+          }
+        );
+      }
+    );
+
+    it('19. Collaborater cannot delete job by job Id',
+      function (done) {
+        collaboraterApiAdapter.deleteJobsById(privateProjectJob.id,
+          function (err, response) {
+            assert.strictEqual(err, 404,
+              util.format('User should not be able to delete job by job Id: %s ' +
+                'err : %s, %s', privateProjectJob.id, err, response)
+            );
+            return done();
+          }
+        );
+      }
+    );
+
+    it('20. Public user cannot delete private job by job Id',
+      function (done) {
+        global.pubAdapter.deleteJobsById(privateProjectJob.id,
+          function (err, response) {
+            assert.strictEqual(err, 401,
+              util.format('User should not be able to delete job by job Id: %s ' +
+                'err : %s, %s', privateProjectJob.id, err, response)
+            );
+            return done();
+          }
+        );
+      }
+    );
+
+    it('21. Public user cannot delete public project job by job Id',
+      function (done) {
+        global.pubAdapter.deleteJobsById(publicProjectJob.id,
+          function (err, response) {
+            assert.strictEqual(err, 401,
+              util.format('User should not be able to delete job by job Id: %s ' +
+                'err : %s, %s', publicProjectJob.id, err, response)
+            );
+            return done();
+          }
+        );
+      }
+    );
+
+    it('22. Unauthorized user cannot delete private job by job Id',
+      function (done) {
+        unauthorizedApiAdapter.deleteJobsById(privateProjectJob.id,
+          function (err, response) {
+            assert.strictEqual(err, 404,
+              util.format('User should not be able to delete job by job Id: %s ' +
+                'err : %s, %s', privateProjectJob.id, err, response)
+            );
+            return done();
+          }
+        );
+      }
+    );
+
+    it('23. Unauthorized user cannot delete public project job by job Id',
+      function (done) {
+        unauthorizedApiAdapter.deleteJobsById(publicProjectJob.id,
+          function (err, response) {
+            assert.strictEqual(err, 404,
+              util.format('User should not be able to delete job by job Id: %s ' +
+                'err : %s, %s', privateProjectJob.id, err, response)
+            );
+            return done();
+          }
+        );
+      }
+    );
+
+    it('24. Owner deletes the private project',
       function (done) {
         var project =  _.first(
           _.where(projects, {isOrg: true, isPrivateRepository: true}
@@ -439,7 +540,7 @@ describe(test,
       }
     );
 
-    it('18. Owner deletes the public project',
+    it('25. Owner deletes the public project',
       function (done) {
         var project =  _.first(
           _.where(projects, {isOrg: true, isPrivateRepository: false}

--- a/tests/core/api/PROJECTS.js
+++ b/tests/core/api/PROJECTS.js
@@ -423,47 +423,79 @@ describe(test,
       }
     );
 
-    it('18. Collaborater can trigger manual build for the private project',
+    it('18. Collaborater triggers manual build for private project and build is successful',
       function (done) {
-        var project =  _.findWhere(projects, {isPrivateRepository: true});
-        assert.isNotEmpty(project,
-          'Projects cannot be empty.');
-        var json = {branchName: 'master'};
-        collaboraterApiAdapter.triggerNewBuildByProjectId(project.id, json,
-          function (err, response) {
-            if (err)
-              return done(
-                new Error(
-                  util.format('user cannot trigger manual build for ' +
-                    'project id: %s, err: %s, %s', project.id, err,
-                    util.inspect(response)
-                  )
-                )
-              );
-            return done();
+        var project =  _.first(
+          _.where(projects, {isOrg: true, isPrivateRepository: true}
+          )
+        );
+        var triggerBuild = new Promise(
+          function (resolve, reject) {
+            var json = {branchName: 'master'};
+            collaboraterApiAdapter.triggerNewBuildByProjectId(project.id, json,
+              function (err, response) {
+                if (err)
+                  return reject(
+                    new Error(
+                      util.format('user cannot trigger manual build for ' +
+                        'project id: %s, err: %s, %s', project.id, err,
+                        util.inspect(response)
+                      )
+                    )
+                  );
+                return resolve(response);
+              }
+            );
+          }
+        );
+
+        triggerBuild.then(
+          function (response) {
+            privateProjectRunId = response.runId;
+            global.getRunByIdStatusWithBackOff(collaboraterApiAdapter, privateProjectRunId,
+              successStatusCode, done);
+          },
+          function (err) {
+            return done(err);
           }
         );
       }
     );
 
-    it('19. Collaborater can trigger manual build for the public project',
+    it('19. Collaborater triggers manual build for public project and build is successful',
       function (done) {
-        var project =  _.findWhere(projects, {isPrivateRepository: false});
-        assert.isNotEmpty(project,
-          'Projects cannot be empty.');
-        var json = {branchName: 'master'};
-        collaboraterApiAdapter.triggerNewBuildByProjectId(project.id, json,
-          function (err, response) {
-            if (err)
-              return done(
-                new Error(
-                  util.format('user cannot trigger manual build for ' +
-                    'project id: %s, err: %s, %s', project.id, err,
-                    util.inspect(response)
-                  )
-                )
-              );
-            return done();
+        var project =  _.first(
+          _.where(projects, {isOrg: true, isPrivateRepository: false}
+          )
+        );
+        var triggerBuild = new Promise(
+          function (resolve, reject) {
+            var json = {branchName: 'master'};
+            collaboraterApiAdapter.triggerNewBuildByProjectId(project.id, json,
+              function (err, response) {
+                if (err)
+                  return reject(
+                    new Error(
+                      util.format('user cannot trigger manual build for ' +
+                        'project id: %s, err: %s, %s', project.id, err,
+                        util.inspect(response)
+                      )
+                    )
+                  );
+                return resolve(response);
+              }
+            );
+          }
+        );
+
+        triggerBuild.then(
+          function (response) {
+            publicProjectRunId = response.runId;
+            global.getRunByIdStatusWithBackOff(collaboraterApiAdapter, publicProjectRunId,
+              successStatusCode, done);
+          },
+          function (err) {
+            return done(err);
           }
         );
       }


### PR DESCRIPTION
All tests are passing in local. Total duration was 25mins

Added Accounts API tests:

![selection_999 1368](https://user-images.githubusercontent.com/15084465/35546654-2a924118-059b-11e8-8716-c2fd0cbdf954.png)
![selection_999 1369](https://user-images.githubusercontent.com/15084465/35546656-2e340ffe-059b-11e8-985c-2d3d370eb466.png)

Added Jobs API tests:
![selection_999 1372](https://user-images.githubusercontent.com/15084465/35546997-97623b76-059c-11e8-8935-ea096767f04d.png)

Projects API added as bug fix sometimes when project was processing if i call delete for that project only ciRepo used to delete so waiting until all builds complete its execution